### PR TITLE
Implemented GitRepository.get_diff method - refers #96

### DIFF
--- a/vcs/backends/hg.py
+++ b/vcs/backends/hg.py
@@ -256,13 +256,32 @@ class MercurialRepository(BaseRepository):
 
         return map(lambda x: hex(x[7]), self._repo.changelog.index)[:-1]
 
-    def get_diff(self, rev1, rev2, path=None, ignore_whitespace=False,
+    def get_diff(self, rev1, rev2, path='', ignore_whitespace=False,
                   context=3):
+        """
+        Returns (git like) *diff*, as plain text. Shows changes introduced by
+        ``rev2`` since ``rev1``.
+
+        :param rev1: Entry point from which diff is shown. Can be
+          ``self.EMPTY_CHANGESET`` - in this case, patch showing all
+          the changes since empty state of the repository until ``rev2``
+        :param rev2: Until which revision changes should be shown.
+        :param ignore_whitespace: If set to ``True``, would not show whitespace
+          changes. Defaults to ``False``.
+        :param context: How many lines before/after changed lines should be
+          shown. Defaults to ``3``.
+        """
+        # Check if given revisions are present at repository (may raise
+        # ChangesetDoesNotExistError)
+        if rev1 != self.EMPTY_CHANGESET:
+            self.get_changeset(rev1)
+        self.get_changeset(rev2)
+
         file_filter = match(self.path, '', [path])
-        return patch.diff(self._repo, rev1, rev2, match=file_filter,
+        return ''.join(patch.diff(self._repo, rev1, rev2, match=file_filter,
                           opts=diffopts(git=True,
                                         ignorews=ignore_whitespace,
-                                        context=context))
+                                        context=context)))
 
     def _check_url(self, url):
         """

--- a/vcs/tests/test_git.py
+++ b/vcs/tests/test_git.py
@@ -645,9 +645,9 @@ class GitSpecificWithRepoTest(BackendTestMixin, unittest.TestCase):
 
     def test_get_diff_runs_git_command_with_str_hashes(self):
         self.repo.run_git_command = mock.Mock(return_value=['', ''])
-        self.repo.get_diff('0' * 40, 1)
-        self.repo.run_git_command.assert_called_once_with('diff -U%s %s %s' %
-            (3, self.repo._get_revision(0), self.repo._get_revision(1)))
+        self.repo.get_diff(self.repo.EMPTY_CHANGESET, 1)
+        self.repo.run_git_command.assert_called_once_with('show -U%s %s' %
+            (3, self.repo._get_revision(1)))
 
     def test_get_diff_runs_git_command_with_path_if_its_given(self):
         self.repo.run_git_command = mock.Mock(return_value=['', ''])


### PR DESCRIPTION
This is first approach. I'm not happy with _EmptyChangeset_, maybe simple static at _GitRepository_ or _GitChangeset_, _EMPTY_REVISION_ (or something) being `"0" * 40` would suffice - this way at least we can assume that _get_diff_ method can take only _hashes_/_integers_, not objects. We still would need to handle that specific case with empty changeset, but in a lighter way I believe.

Also, if you can, please take a look at new tests for _get_diff_ method for mercurial backend (they are failing, and maybe you can fix them easily - if not, please write down your impression too as it may be harder to write generic tests for all backends :)).

Moreover, let's discuss implementation here, not at #96, so we can easily see what's going on in this branch.
