### PR TITLE
fix for issue #106

### DIFF
--- a/vcs/backends/git/workdir.py
+++ b/vcs/backends/git/workdir.py
@@ -20,8 +20,8 @@ class GitWorkdir(BaseWorkdir):
             raise RepositoryError("Couldn't compute workdir's branch")
 
     def get_changeset(self):
-        return self.repository.get_changeset(
-            self.repository._repo.refs.as_dict().get('HEAD'))
+        wk_dir_id = self.repository._repo.refs.as_dict().get('HEAD')
+        return self.repository.get_changeset(wk_dir_id)
 
     def checkout_branch(self, branch=None):
         if branch is None:

--- a/vcs/backends/hg/workdir.py
+++ b/vcs/backends/hg/workdir.py
@@ -10,7 +10,8 @@ class MercurialWorkdir(BaseWorkdir):
         return self.repository._repo.dirstate.branch()
 
     def get_changeset(self):
-        return self.repository.get_changeset()
+        wk_dir_id = self.repository._repo[None].parents()[0].hex()
+        return self.repository.get_changeset(wk_dir_id)
 
     def checkout_branch(self, branch=None):
         if branch is None:


### PR DESCRIPTION
fixes #106
- the workdir get_changeset method should return currently checked out
  revision and not the latest one in repository

note: the tests are broken because of that changeset, not sure how to fix them, looks like
something get's cached
