### PR TITLE
Fixed get_changesets filter criteria problem

### DIFF
--- a/vcs/backends/hg/repository.py
+++ b/vcs/backends/hg/repository.py
@@ -488,14 +488,12 @@ class MercurialRepository(BaseRepository):
         if branch_name:
             filter_.append('branch("%s")' % (branch_name))
 
-        if start_date and not end_date:
+        if start_date:
             filter_.append('date(">%s")' % start_date)
-        if end_date and not start_date:
+        if end_date:
             filter_.append('date("<%s")' % end_date)
-        if start_date and end_date:
-            filter_.append('date(">%s") and date("<%s")' % (start_date, end_date))
         if filter_:
-            revisions = scmutil.revrange(self._repo, filter_)
+            revisions = scmutil.revrange(self._repo, [" and ".join(filter_)])
         else:
             revisions = self.revisions
 

--- a/vcs/tests/test_changesets.py
+++ b/vcs/tests/test_changesets.py
@@ -203,21 +203,30 @@ class ChangesetsTestCaseMixin(BackendTestMixin):
         self.assertEqual(changesets[-1].raw_id, second_id)
 
     def test_get_changesets_respects_start_date(self):
-        start_date = datetime.datetime(2010, 2, 1)
+        start_date = datetime.datetime(2010, 1, 2)
         for cs in self.repo.get_changesets(start_date=start_date):
             self.assertGreaterEqual(cs.date, start_date)
 
     def test_get_changesets_respects_end_date(self):
+        end_date = datetime.datetime(2010, 1, 2)
+        for cs in self.repo.get_changesets(end_date=end_date):
+            self.assertLessEqual(cs.date, end_date)
+
+    def test_get_changesets_respects_start_date_and_end_date(self):
         start_date = datetime.datetime(2010, 1, 1)
-        end_date = datetime.datetime(2010, 2, 1)
+        end_date = datetime.datetime(2010, 1, 3)
         for cs in self.repo.get_changesets(start_date=start_date,
                                            end_date=end_date):
             self.assertGreaterEqual(cs.date, start_date)
             self.assertLessEqual(cs.date, end_date)
 
-    def test_get_changesets_respects_start_date_and_end_date(self):
-        end_date = datetime.datetime(2010, 2, 1)
-        for cs in self.repo.get_changesets(end_date=end_date):
+    def test_get_changesets_respects_start_date_and_end_date_and_branch_name(self):
+        start_date = datetime.datetime(2010, 1, 1)
+        end_date = datetime.datetime(2010, 1, 3)
+        for cs in self.repo.get_changesets(start_date=start_date,
+                                           end_date=end_date,
+                                           branch_name=self.repo.DEFAULT_BRANCH_NAME):
+            self.assertGreaterEqual(cs.date, start_date)
             self.assertLessEqual(cs.date, end_date)
 
     def test_get_changesets_respects_reverse(self):


### PR DESCRIPTION
- prepare filter criteria with AND operator for get_changesets
- fixed typo in test function name from last commit
- changed date ranges for get_changesets tests with date criteria
  (test data is only between 2010-01-01 - 2010-01-03)
- extra test with all criteria (start_date, end_date, branch_name)
